### PR TITLE
Added :refer-clojure :exclude for promise for actors namespace

### DIFF
--- a/src/main/clojure/co/paralleluniverse/pulsar/actors.clj
+++ b/src/main/clojure/co/paralleluniverse/pulsar/actors.clj
@@ -12,6 +12,7 @@
 
 (ns co.paralleluniverse.pulsar.actors
   "Defines actors and behaviors like gen-server and supervisor"
+  (:refer-clojure :exclude [promise])
   (:import [java.util.concurrent TimeUnit ExecutionException TimeoutException]
            [co.paralleluniverse.fibers FiberScheduler]
            [co.paralleluniverse.strands Strand]


### PR DESCRIPTION
When referring to co.paralleluniverse.pulsar.actor I get following error message:

IllegalStateException promise already refers to: #'co.paralleluniverse.pulsar.core/promise in namespace: co.paralleluniverse.pulsar.actors  clojure.lang.Namespace.warnOrFailOnReplace (Namespace.java:88) and the loading fails.

Used namespace declaration is following:

``` clojure
(ns ptest
  (:refer-clojure :exclude [promise])
  (:require [co.paralleluniverse.pulsar.core :refer :all] :reload
               [co.paralleluniverse.pulsar.actors :as a] :reload))
```

The error message doesn't happen if only accessing pulsar.core.

After adding the (:refer-clojure :exclude [promise]) to actors namespace the problem doesn't appear anymore.

Probably this happens because actors namespace refer pulsar.core :all.
