### PR TITLE
The original example does not return what is commented.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -246,7 +246,7 @@ Here's an example from the tests:
   fiber (spawn-fiber
       (fn []
           (await service 2 5)))]
-          (join fiber))
+          (join fiber)) ; => 7
 ~~~
 
 #### Strands


### PR DESCRIPTION
The original example returned the Fiber and is confusing, since the comment says that it should return the value of 7 (; => 7).  This caused me some confusion and made the instructions a little more difficult to follow.

Also the test example falls in line with the changes I made.
# <Fiber Fiber@10000037[task: ParkableForkJoinTask@4347197b(Fiber@10000037), target: co.paralleluniverse.pulsar.ClojureHelper$3@70d9fcbe, scheduler: co.paralleluniverse.fibers.FiberForkJoinScheduler@4787a03c]>
