### PR TITLE
Add (last) to excluded clojure fn's to get rid of warning

### DIFF
--- a/src/main/clojure/co/paralleluniverse/pulsar/async.clj
+++ b/src/main/clojure/co/paralleluniverse/pulsar/async.clj
@@ -17,7 +17,7 @@
 ;
 (ns co.paralleluniverse.pulsar.async
   "Fiber-based implementation of [org.clojure/core.async \"0.1.346.0-17112a-alpha\"]"
-  (:refer-clojure :exclude [reduce into merge map take partition partition-by] :as core)
+  (:refer-clojure :exclude [reduce into merge map take partition partition-by last] :as core)
   (:require
     [co.paralleluniverse.pulsar.core :as p :refer [defsfn sfn]])
   (:import


### PR DESCRIPTION
Just a warning that has bugged me since starting using the library :^

`WARNING: last already refers to: #'clojure.core/last in namespace: co.paralleluniverse.pulsar.async, being replaced by: #'co.paralleluniverse.pulsar.async/last`